### PR TITLE
[refactor] 홈 화면 API 연동 개선

### DIFF
--- a/src/hooks/Mbti/useGetMbtiTestResult.ts
+++ b/src/hooks/Mbti/useGetMbtiTestResult.ts
@@ -7,23 +7,40 @@ export const useGetMbtiTestResult = () => {
   return useQuery({
     queryKey: ['mbtiResult'],
     queryFn: async () => {
-      const [myRes, typesRes] = await Promise.all([getFinanceMbtiResultApi(), getMbtiTypeDetails()]);
+      try {
+        const [myRes, typesRes] = await Promise.all([
+          getFinanceMbtiResultApi().catch(() => null), // MBTI 결과가 없을 수 있음
+          getMbtiTypeDetails().catch(() => null), // MBTI 타입 상세 정보
+        ]);
 
-      if (!myRes.result || !typesRes.result) throw new Error('데이터 로드 실패');
+        // MBTI 결과가 없으면 null 반환
+        if (!myRes?.result || !typesRes?.result) {
+          return null;
+        }
 
-      const myData = myRes.result;
-      const serverDetail = typesRes.result.find((t) => t.type === myData.resultType);
+        const myData = myRes.result;
+        const serverDetail = typesRes.result.find((t) => t.type === myData.resultType);
 
-      const localExtension = MBTI_LOCAL_EXTENSIONS[myData.resultType] || {
-        icon: DefaultIcon,
-        extraDescription: '',
-      };
+        // 서버에서 해당 타입의 상세 정보를 찾지 못한 경우 기본값 사용
+        if (!serverDetail) {
+          return null;
+        }
 
-      return {
-        ...myData, // 내 점수 (anxietyScore 등)
-        ...serverDetail, // 서버의 유형 설명 (title, tagline 등)
-        ...localExtension, // 내가 직접 만든 아이콘과 추가 설명
-      };
+        const localExtension = MBTI_LOCAL_EXTENSIONS[myData.resultType] || {
+          icon: DefaultIcon,
+          extraDescription: '',
+        };
+
+        return {
+          ...myData, // 내 점수 (anxietyScore 등)
+          ...serverDetail, // 서버의 유형 설명 (title, tagline 등)
+          ...localExtension, // 내가 직접 만든 아이콘과 추가 설명
+        };
+      } catch (error) {
+        console.error('MBTI 결과 조회 실패:', error);
+        return null;
+      }
     },
+    retry: false, // MBTI 결과가 없을 때는 재시도하지 않음
   });
 };

--- a/src/pages/Splash/SplashPage.tsx
+++ b/src/pages/Splash/SplashPage.tsx
@@ -20,13 +20,7 @@ const SplashPage = () => {
   return (
     <div className={cn('relative min-h-screen w-full overflow-hidden bg-white')}>
       <div className={cn('absolute inset-0', 'flex items-center justify-center', 'overflow-hidden')}>
-        <div
-          className={cn(
-            'relative',
-            'w-screen h-screen min-w-full min-h-full',
-            'md:w-screen md:h-screen'
-          )}
-        >
+        <div className={cn('relative', 'w-screen h-screen min-w-full min-h-full', 'md:w-screen md:h-screen')}>
           <img
             src={splashBg}
             alt=""
@@ -53,13 +47,7 @@ const SplashPage = () => {
           </div>
 
           {/* 중앙 로고 - Figma 디자인 기준: left-[908.13px] top-[425.31px] w-[100px] h-[23px] */}
-          <div
-            className={cn(
-              'flex items-center justify-center',
-              'w-[100px] h-[23px]',
-              'md:w-[140px] md:h-[32px]'
-            )}
-          >
+          <div className={cn('flex items-center justify-center', 'w-[100px] h-[23px]', 'md:w-[140px] md:h-[32px]')}>
             <img src={splashLogo} alt="Valuedi" className={cn('w-full h-full object-contain')} />
           </div>
         </div>


### PR DESCRIPTION
# [refactor] 홈 화면 API 연동 개선

## 📝 변경 내용
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
**오늘 및 어제 지출 내역 API 연동 (HomePage.tsx)**
- getDailyTransactionsApi 추가: 일별 거래 내역 조회
- 상태 추가: todayExpense, yesterdayExpense
- 오늘/어제 날짜 계산 후 해당 일의 지출 금액 표시
- 하드코딩된 formatCurrency(0) 제거

**MBTI 캐릭터 표시 개선 (HomePage.tsx)**
- useGetMbtiTestResult 훅 추가: 실제 MBTI 결과 데이터 조회
- 동적 아이콘 표시: 사용자 MBTI 타입에 맞는 캐릭터 아이콘 표시
- 배경색 제거: bg-atomic-yellow-95 제거
- 크기 조정: 아이콘 크기 120%로 확대, 패딩 제거

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #89 

## 🎯 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI/UX 개선
- [x] 리팩토링
- [ ] 문서 업데이트

## 📱 테스트
- [x] 브라우저에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인

## 📸 스크린샷 (UI 변경시)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1470" height="956" alt="스크린샷 2026-02-11 오전 6 28 13" src="https://github.com/user-attachments/assets/f523139b-7f72-46e6-85c7-cbdb56f5c7e9" />


## 📋 체크리스트
- [x] 코드가 정상적으로 동작합니다
- [x] 새로운 에러나 경고가 없습니다
- [x] 필요시 문서를 업데이트했습니다
- [x] 코드 포맷팅을 실행했습니다 (`npm run format`)
- [x] ESLint 검사를 통과했습니다 (`npm run lint:fix`)

## 💻 코드 품질 확인
PR 제출 전에 다음 명령어를 실행하여 코드 품질을 확인해주세요:

```bash
# ESLint 자동 수정
npm run lint:fix

# Prettier 포맷팅
npm run format
```

