### PR TITLE
[fix] 가계부 내부 동일한 달력 일수 노출 오류 해결

### DIFF
--- a/src/pages/Asset/tab/AssetDetails/components/LedgerCalendar.tsx
+++ b/src/pages/Asset/tab/AssetDetails/components/LedgerCalendar.tsx
@@ -12,6 +12,20 @@ const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 export const LedgerCalendar = () => {
   const currentMonth = useLedgerStore((state) => state.currentMonth);
 
+  const currentYear = new Date().getFullYear();
+
+  const { startDayIndex, totalDays } = useMemo(() => {
+    // 해당 월의 1일 객체 생성
+    const firstDay = new Date(currentYear, currentMonth - 1, 1);
+    // 해당 월의 마지막 날 객체 생성 (다음 달의 0일은 이번 달의 마지막 날)
+    const lastDay = new Date(currentYear, currentMonth, 0);
+
+    return {
+      startDayIndex: firstDay.getDay(), // 0(일) ~ 6(토)
+      totalDays: lastDay.getDate(), // 28, 29, 30, 31 등 실재하는 일수
+    };
+  }, [currentYear, currentMonth]);
+
   const yearMonth = useMemo(() => {
     const year = new Date().getFullYear();
     return `${year}-${String(currentMonth).padStart(2, '0')}`;
@@ -32,9 +46,6 @@ export const LedgerCalendar = () => {
     return dataMap;
   }, [transactionHistory]);
 
-  const startDayIndex = 3; // 수요일을 1일로 가정
-  const totalDays = 31;
-  // startDayIndex 기준으로 빈칸(null)을 만들고, 1일부터 말일까지의 숫자를 만듭니다.
   const daysArray = [...Array(startDayIndex).fill(null), ...Array.from({ length: totalDays }, (_, i) => i + 1)];
 
   const selectedData = selectedDate ? calendarData[selectedDate] : null;


### PR DESCRIPTION
# Pull Request

## 📝 변경 내용
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 가계부 내부 동일한 달력 일수 노출 오류 해결

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #134 

## 🎯 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI/UX 개선
- [ ] 리팩토링
- [ ] 문서 업데이트

## 📱 테스트
- [x] 브라우저에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인

## 📸 스크린샷 (UI 변경시)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="471" height="803" alt="스크린샷(1664)" src="https://github.com/user-attachments/assets/d0a8ad1a-36e0-4f21-8310-e94b2f64f85f" />
<img width="472" height="821" alt="스크린샷(1665)" src="https://github.com/user-attachments/assets/2a96e54a-778b-4b84-a485-92916fedf214" />


## 📋 체크리스트
- [x] 코드가 정상적으로 동작합니다
- [x] 새로운 에러나 경고가 없습니다
- [x] 필요시 문서를 업데이트했습니다
- [x] 코드 포맷팅을 실행했습니다 (`npm run format`)
- [x] ESLint 검사를 통과했습니다 (`npm run lint:fix`)

## 💻 코드 품질 확인
PR 제출 전에 다음 명령어를 실행하여 코드 품질을 확인해주세요:

```bash
# ESLint 자동 수정
npm run lint:fix

# Prettier 포맷팅
npm run format
```

