### PR TITLE
[refactor] 가계부 태블릿 뷰 레이아웃 수정

### DIFF
--- a/src/pages/Asset/tab/AssetDetails/AssetDetailsPage.tsx
+++ b/src/pages/Asset/tab/AssetDetails/AssetDetailsPage.tsx
@@ -24,7 +24,7 @@ export const AssetDetails = () => {
 
   return (
     <div className={cn('flex flex-col w-full h-full bg-neutral-0')}>
-      <div className={cn('px-[20px] pt-[20px]')}>
+      <div className={cn('px-[20px] md:px-[32px] lg:px-[40px] pt-[20px]')}>
         <SegmentedButton<ViewType> value={viewType} onChange={setViewType} options={viewOptions} />
       </div>
 

--- a/src/pages/Asset/tab/AssetDetails/components/AssetLedger.tsx
+++ b/src/pages/Asset/tab/AssetDetails/components/AssetLedger.tsx
@@ -66,7 +66,7 @@ export const AssetLedger = () => {
   const isLoading = isSummaryLoading || isTopCategoryLoading || isDailyLoading;
 
   return (
-    <div className={cn('flex flex-col w-full h-full bg-neutral-0 mt-[20px] px-[20px] gap-[20px]')}>
+    <div className={cn('flex flex-col w-full h-full bg-neutral-0 mt-[20px] px-[20px] md:px-[32px] lg:px-[40px] gap-[20px]')}>
       <div className={cn('flex flex-col gap-[20px]')}>
         <div className={cn('flex flex-col gap-[12px]')}>
           <div className={cn('flex items-center gap-[8px] py-[4px]')}>
@@ -141,13 +141,15 @@ export const AssetLedger = () => {
         </div>
       </div>
 
-      <div className={cn('h-[8px] bg-neutral-10 mx-[-20px]')} />
+      <div className={cn('h-[8px] bg-neutral-10 mx-[-20px] md:mx-[-32px] lg:mx-[-40px]')} />
 
-      <div className={cn('flex flex-col gap-[12px] w-full h-full')}>
+      <div className={cn('flex flex-col gap-[12px] w-full')}>
         <ViewToggleButton mode={viewMode} onToggle={setViewMode} leftText="목록" rightText="달력" />
       </div>
 
-      {viewMode === 'list' ? <LedgerList /> : <LedgerCalendar />}
+      <div className={cn('flex-1 min-h-0 w-full overflow-y-auto')}>
+        {viewMode === 'list' ? <LedgerList /> : <LedgerCalendar />}
+      </div>
     </div>
   );
 };

--- a/src/pages/Asset/tab/AssetDetails/components/AssetList.tsx
+++ b/src/pages/Asset/tab/AssetDetails/components/AssetList.tsx
@@ -37,7 +37,7 @@ export const AssetList = () => {
   const [isCardExpanded, setIsCardExpanded] = useState(false);
 
   return (
-    <div className={cn('flex flex-col gap-[8px] px-[20px] mt-[20px] ')}>
+    <div className={cn('flex flex-col gap-[8px] px-[20px] md:px-[32px] lg:px-[40px] mt-[20px]')}>
       <div className={cn('rounded-[8px] px-[12px] py-[16px] gap-[2px]')}>
         <div className={cn('flex flex-col gap-[2px]')}>
           <Typography style="text-body-2-14-regular" className="text-neutral-70">

--- a/src/pages/Asset/tab/AssetDetails/components/LedgerCalendar.tsx
+++ b/src/pages/Asset/tab/AssetDetails/components/LedgerCalendar.tsx
@@ -52,9 +52,9 @@ export const LedgerCalendar = () => {
 
   return (
     <div className={cn('flex flex-col w-full')}>
-      <div className={cn('grid grid-cols-7')}>
+      <div className={cn('grid grid-cols-7 w-full')}>
         {WEEKDAYS.map((day) => (
-          <div key={day} className={cn('flex justify-center items-center py-[4px] gap-[4px] w-[44px]')}>
+          <div key={day} className={cn('flex justify-center items-center py-[4px] gap-[4px]')}>
             <Typography style="text-caption-1-12-regular" className={cn('text-neutral-90')}>
               {day}
             </Typography>
@@ -62,7 +62,7 @@ export const LedgerCalendar = () => {
         ))}
       </div>
 
-      <div className={cn('grid grid-cols-7 py-[4px]')}>
+      <div className={cn('grid grid-cols-7 w-full py-[4px]')}>
         {daysArray.map((date, index) => {
           if (!date) return <div key={`empty-${index}`} />;
 
@@ -74,7 +74,7 @@ export const LedgerCalendar = () => {
               onClick={() => {
                 if (data) setSelectedDate(date);
               }}
-              className={cn('flex flex-col items-center w-[44px] h-[70px] py-[4px]', data && 'cursor-pointer')}
+              className={cn('flex flex-col items-center h-[70px] py-[4px]', data && 'cursor-pointer')}
             >
               <div className={cn('flex gap-[4px] py-[8px]')}>
                 <Typography style="text-body-2-14-medium" className={cn(data ? 'text-neutral-90' : 'text-neutral-50')}>

--- a/src/pages/Asset/tab/SectorAnalysis/sections/SectorSummarySection.tsx
+++ b/src/pages/Asset/tab/SectorAnalysis/sections/SectorSummarySection.tsx
@@ -70,20 +70,28 @@ export const SectorSummarySection = ({
           <SectorChartSkeleton />
         ) : (
           <SectorChart
-            data={[
-              ...sectorData.slice(0, 5),
-              ...(sectorData.slice(5).reduce((sum, i) => sum + i.amount, 0) > 0
-                ? [
-                    {
+            data={(() => {
+              // others가 아닌 항목들만 상위 5개 선택
+              const nonOthersItems = sectorData.filter((item) => item.key !== 'others').slice(0, 5);
+              
+              // 모든 others 항목을 찾아서 합치기
+              const allOthersItems = sectorData.filter((item) => item.key === 'others');
+              const mergedOthers =
+                allOthersItems.length > 0
+                  ? {
                       key: 'others',
-                      amount: sectorData.slice(5).reduce((sum, i) => sum + i.amount, 0),
-                      percentage: sectorData.slice(5).reduce((sum, i) => sum + i.percentage, 0),
+                      amount: allOthersItems.reduce((sum, i) => sum + i.amount, 0),
+                      percentage: allOthersItems.reduce((sum, i) => sum + i.percentage, 0),
                       category: 'others',
                       items: [],
-                    },
-                  ]
-                : []),
-            ]}
+                    }
+                  : null;
+
+              // others가 있고 금액이 0보다 크면 추가
+              return mergedOthers && mergedOthers.amount > 0
+                ? [...nonOthersItems, mergedOthers]
+                : nonOthersItems;
+            })()}
           />
         )}
       </div>


### PR DESCRIPTION
# Pull Request

## 📝 변경 내용
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 가계부 달력 부분 공백 제거 및 중앙 정렬

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #142 

## 🎯 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI/UX 개선
- [x] 리팩토링
- [ ] 문서 업데이트

## 📱 테스트
- [x] 브라우저에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인

## 📸 스크린샷 (UI 변경시)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/54e13a97-81b5-47d0-8c73-3e12211a8b98



## 📋 체크리스트
- [x] 코드가 정상적으로 동작합니다
- [x] 새로운 에러나 경고가 없습니다
- [ ] 필요시 문서를 업데이트했습니다
- [x] 코드 포맷팅을 실행했습니다 (`npm run format`)
- [x] ESLint 검사를 통과했습니다 (`npm run lint:fix`)

## 💻 코드 품질 확인
PR 제출 전에 다음 명령어를 실행하여 코드 품질을 확인해주세요:

```bash
# ESLint 자동 수정
npm run lint:fix

# Prettier 포맷팅
npm run format
```

