### PR TITLE
[refactor] 목표 달성 계산 기준 및 남은 금액/현재 자산 UI 로직 수정

### DIFF
--- a/src/features/goal/goal.api.ts
+++ b/src/features/goal/goal.api.ts
@@ -60,26 +60,8 @@ export const goalApi = {
   // 목표 추가
 
   async createGoal(data: CreateGoalRequest): Promise<CreateGoalResponse> {
-    console.log('목표 생성 API 요청:', {
-      endpoint: GOALS_PATH_PREFIX,
-      method: 'POST',
-      data,
-    });
-
-    try {
-      const result = await apiPost<CreateGoalResponse['result']>(GOALS_PATH_PREFIX, data);
-      console.log('목표 생성 성공:', result);
-      return result as CreateGoalResponse;
-    } catch (error) {
-      if (error instanceof ApiError) {
-        console.error('서버 에러 응답:', {
-          code: error.code,
-          message: error.message,
-          status: error.status,
-        });
-      }
-      throw error;
-    }
+    const result = await apiPost<CreateGoalResponse['result']>(GOALS_PATH_PREFIX, data);
+    return result as CreateGoalResponse;
   },
 
   // 목표 상세 조회
@@ -121,47 +103,14 @@ export const goalApi = {
   // 목표-계좌 연결
 
   async linkAccount(goalId: number, data: LinkAccountRequest): Promise<LinkAccountResponse> {
-    console.log('목표-계좌 연결 API 요청:', {
-      endpoint: `${GOALS_PATH_PREFIX}/${goalId}/linked-accounts`,
-      method: 'PUT',
-      goalId,
-      data,
-    });
-
-    try {
-      const result = await apiPut<LinkAccountResponse['result']>(
-        `${GOALS_PATH_PREFIX}/${goalId}/linked-accounts`,
-        data
-      );
-      console.log('계좌 연결 성공:', result);
-      return result as LinkAccountResponse;
-    } catch (error) {
-      if (error instanceof ApiError) {
-        console.error('서버 에러 응답:', {
-          code: error.code,
-          message: error.message,
-          status: error.status,
-        });
-      }
-      throw error;
-    }
+    const result = await apiPut<LinkAccountResponse['result']>(`${GOALS_PATH_PREFIX}/${goalId}/linked-accounts`, data);
+    return result as LinkAccountResponse;
   },
 
   // 목표 수정
   async updateGoal(goalId: number, data: UpdateGoalRequest): Promise<UpdateGoalResponse> {
-    try {
-      const result = await apiPatch<UpdateGoalResponse['result']>(`${GOALS_PATH_PREFIX}/${goalId}`, data);
-      return result as UpdateGoalResponse;
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 400) {
-        console.error('목표 수정 400 에러 응답:', {
-          code: error.code,
-          message: error.message,
-          status: error.status,
-        });
-      }
-      throw error;
-    }
+    const result = await apiPatch<UpdateGoalResponse['result']>(`${GOALS_PATH_PREFIX}/${goalId}`, data);
+    return result as UpdateGoalResponse;
   },
 
   // 목표 삭제

--- a/src/features/goal/goal.types.ts
+++ b/src/features/goal/goal.types.ts
@@ -6,6 +6,8 @@ export interface Goal {
   goalId: number;
   title: string;
   savedAmount: number;
+  targetAmount?: number;
+  currentBalance?: number;
   remainingDays: number;
   achievementRate: number;
   status: GoalStatus;
@@ -62,6 +64,7 @@ export interface GoalDetail {
   goalId: number;
   title: string;
   savedAmount: number;
+  currentBalance?: number;
   targetAmount: number;
   remainingDays: number;
   achievementRate: number;
@@ -70,6 +73,8 @@ export interface GoalDetail {
   account: {
     bankName: string;
     accountNumber: string;
+    balanceAmount?: number;
+    currentBalance?: number;
   };
   status: GoalStatus;
   colorCode: string;

--- a/src/pages/Asset/tab/AssetDetails/components/AssetList.tsx
+++ b/src/pages/Asset/tab/AssetDetails/components/AssetList.tsx
@@ -10,6 +10,7 @@ import { MoreViewButton } from '@/shared/components/buttons';
 import { useNavigate } from 'react-router-dom';
 import { ColorToken, getColorToken } from '@/shared/styles/design-system';
 import CheckDownIcon from '@/assets/icons/CheckDown.svg?react';
+import MoreViewIcon from '@/assets/icons/MoreView.svg?react';
 import { useGetAssetList } from '@/shared/hooks/Asset/useGetAssetList';
 import { BANKS } from '@/features/bank/constants/banks';
 import { CARDS } from '@/features/card/constants/cards';
@@ -177,7 +178,9 @@ export const AssetList = () => {
             은행 추가하기
           </Typography>
         </div>
-        <MoreViewButton />
+        <span className="flex items-center justify-center w-[15px] h-[10px] md:w-[20px] md:h-[20px]">
+          <MoreViewIcon className="text-neutral-50 w-full h-full" />
+        </span>
       </button>
 
       <button
@@ -193,7 +196,9 @@ export const AssetList = () => {
             카드 추가하기
           </Typography>
         </div>
-        <MoreViewButton />
+        <span className="flex items-center justify-center w-[15px] h-[10px] md:w-[20px] md:h-[20px]">
+          <MoreViewIcon className="text-neutral-50 w-full h-full" />
+        </span>
       </button>
     </div>
   );

--- a/src/pages/Asset/tab/CompareAnalysis/components/CategoryCompareSection.tsx
+++ b/src/pages/Asset/tab/CompareAnalysis/components/CategoryCompareSection.tsx
@@ -72,10 +72,6 @@ export const CategoryCompareSection = ({ isLoading = false }: CategoryCompareSec
     const total = items
       .filter((item) => normalizeCategoryCode(item.categoryCode, item.categoryName) === selectedCategory)
       .reduce((sum, item) => sum + (item.totalAmount ?? 0), 0);
-    // 디버깅용 로그: 카테고리별 원본 데이터와 계산 결과 확인
-    console.log('[CategoryCompare] raw items', items);
-    console.log('[CategoryCompare] selectedCategory', selectedCategory);
-    console.log('[CategoryCompare] myCategoryTotal', total);
     return total;
   }, [data, selectedCategory]);
 

--- a/src/pages/Goal/Detail/SavingSimulationPage.tsx
+++ b/src/pages/Goal/Detail/SavingSimulationPage.tsx
@@ -7,6 +7,7 @@ import GoalDetailPageHeader from '@/shared/components/goal/detail/GoalDetailPage
 import GoalProgressGauge from '@/shared/components/goal/detail/GoalProgressGauge';
 import GoalSummaryCard from '@/shared/components/goal/detail/GoalSummaryCard';
 import { useGoalDetailActions, useGoalDetailSheetInitials } from '@/shared/hooks/Goal/useGoalDetailActions';
+import { getCollectedAmount } from '@/shared/utils/goal/goalHelpers';
 
 const SavingSimulationPage = () => {
   const {
@@ -32,7 +33,7 @@ const SavingSimulationPage = () => {
 
   // ====== 목표 계산기 시뮬레이션 상태 ======
   const originalRemainingDays = useMemo(() => (detail ? detail.remainingDays : 0), [detail]);
-  const savedAmount = useMemo(() => (detail ? detail.savedAmount : 0), [detail]);
+  const collectedAmount = useMemo(() => (detail ? getCollectedAmount(detail) : 0), [detail]);
 
   const [simulatedRemainingDays, setSimulatedRemainingDays] = useState(originalRemainingDays);
   // 목표 계산기에서 입력한 절약 금액 총합 (게이지/요약에 반영)
@@ -40,7 +41,7 @@ const SavingSimulationPage = () => {
 
   const handleSavingTotalChange = (totalSavingAmount: number) => {
     // 조정 전 남은 목표 금액
-    const originalRemainingGoalAmount = Math.max((detail ? detail.targetAmount : 0) - savedAmount, 0);
+    const originalRemainingGoalAmount = Math.max((detail ? detail.targetAmount : 0) - collectedAmount, 0);
 
     // 줄어든 목표 금액 (남은 금액보다 더 줄일 수 없음)
     const reducedGoalAmount = Math.max(0, Math.min(totalSavingAmount, originalRemainingGoalAmount));

--- a/src/pages/Goal/Detail/SavingSimulationPage.tsx
+++ b/src/pages/Goal/Detail/SavingSimulationPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { MobileLayout } from '@/shared/components/layout/MobileLayout';
+import { useAccounts } from '@/features/asset';
 import SavingList from '@/shared/components/goal/detail/SavingList';
 import GoalMoreActionsBottomSheet from '@/shared/components/goal/detail/GoalMoreActionsBottomSheet';
 import GoalDeleteConfirmModal from '@/shared/components/goal/detail/GoalDeleteConfirmModal';
@@ -10,6 +11,7 @@ import { useGoalDetailActions, useGoalDetailSheetInitials } from '@/shared/hooks
 import { getCollectedAmount } from '@/shared/utils/goal/goalHelpers';
 
 const SavingSimulationPage = () => {
+  const { data: accountsData } = useAccounts();
   const {
     id,
     isGoalLoading,
@@ -33,10 +35,18 @@ const SavingSimulationPage = () => {
 
   // ====== 목표 계산기 시뮬레이션 상태 ======
   const originalRemainingDays = useMemo(() => (detail ? detail.remainingDays : 0), [detail]);
-  const collectedAmount = useMemo(() => (detail ? getCollectedAmount(detail) : 0), [detail]);
+  const linkedAccountBalance = useMemo(
+    () =>
+      accountsData?.result?.accountList?.find((account) => account.goalInfo?.goalId === goal?.goalId)?.balanceAmount,
+    [accountsData, goal?.goalId]
+  );
+  const collectedAmount = useMemo(
+    () => linkedAccountBalance ?? (detail ? getCollectedAmount(detail) : 0),
+    [linkedAccountBalance, detail]
+  );
 
   const [simulatedRemainingDays, setSimulatedRemainingDays] = useState(originalRemainingDays);
-  // 목표 계산기에서 입력한 절약 금액 총합 (게이지/요약에 반영)
+  // 목표 계산기에서 입력한 추가 절약 금액 총합 (게이지/요약에 반영)
   const [simulatedSavingAmount, setSimulatedSavingAmount] = useState(0);
 
   const handleSavingTotalChange = (totalSavingAmount: number) => {

--- a/src/pages/Goal/List/CurrentGoalPage.tsx
+++ b/src/pages/Goal/List/CurrentGoalPage.tsx
@@ -100,10 +100,12 @@ export const CurrentGoalPage = () => {
                         id: goal.goalId,
                         title: goal.title,
                         progress: goal.achievementRate,
-                        targetAmount: goal.savedAmount,
+                        targetAmount: goal.targetAmount ?? goal.savedAmount,
                         remainingDays: goal.remainingDays,
                         colorCode: goal.colorCode,
                         iconId: goal.iconId,
+                        savedAmount: goal.savedAmount,
+                        collectedAmount: goal.currentBalance,
                       }}
                       type="current"
                     />

--- a/src/pages/Goal/List/PastGoalPage.tsx
+++ b/src/pages/Goal/List/PastGoalPage.tsx
@@ -89,12 +89,13 @@ export const PastGoalPage = () => {
                         id: goal.goalId,
                         title: goal.title,
                         progress: goal.achievementRate,
-                        targetAmount: goal.savedAmount,
+                        targetAmount: goal.targetAmount ?? goal.savedAmount,
                         remainingDays: goal.remainingDays,
                         colorCode: goal.colorCode,
                         iconId: goal.iconId,
                         status: goal.status,
                         savedAmount: goal.savedAmount,
+                        collectedAmount: goal.currentBalance,
                       }}
                       type="past"
                     />

--- a/src/pages/Recommend/RecommendPage.tsx
+++ b/src/pages/Recommend/RecommendPage.tsx
@@ -78,7 +78,10 @@ export const RecommendPage = () => {
   // Top3 추천 데이터 호출
   const { data: topData } = useTop3Recommendations();
 
-  const top3Products = topData?.products || [];
+  const top3Products = useMemo(() => {
+    const items = topData?.products || [];
+    return Array.from(new Map(items.map((item) => [item.finPrdtCd, item])).values());
+  }, [topData?.products]);
 
   // 추천 생성 성공 시 폴링 시작, 실패 시 폴링 중지
   useEffect(() => {
@@ -184,9 +187,9 @@ export const RecommendPage = () => {
                   'lg:gap-[24px]'
                 )}
               >
-                {top3Products.map((product) => (
+                {top3Products.map((product, index) => (
                   <RecommendBannerCard
-                    key={product.finPrdtCd}
+                    key={`${product.finPrdtCd}-${index}`}
                     title={product.finPrdtNm}
                     subTitle={product.korCoNm}
                     bankId={getBankIdByName(product.korCoNm)}
@@ -300,9 +303,9 @@ export const RecommendPage = () => {
                       <div
                         className={cn('flex flex-col gap-[4px] md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-[12px]')}
                       >
-                        {(isExpanded ? filteredList : filteredList.slice(0, 6)).map((product) => (
+                        {(isExpanded ? filteredList : filteredList.slice(0, 6)).map((product, index) => (
                           <RecommendListItem
-                            key={product.finPrdtCd}
+                            key={`${product.finPrdtCd}-${index}`}
                             bankName={product.korCoNm}
                             productName={product.finPrdtNm}
                             description={`${product.rsrvTypeNm} | ${product.korCoNm}`}

--- a/src/shared/components/goal/GoalCard.tsx
+++ b/src/shared/components/goal/GoalCard.tsx
@@ -5,6 +5,7 @@ import CalendarIcon from '@/assets/icons/goal/CalendarIcon.svg';
 import { toHexColor, type GoalStatus } from '@/features/goal';
 import { GOAL_ICON_SRC } from '@/shared/components/goal/goalIconAssets';
 import ExBank from '@/assets/icons/goal/ExBank.svg';
+import { isGoalAchieved } from '@/shared/utils/goal/goalHelpers';
 
 interface GoalCardProps {
   goal: {
@@ -18,6 +19,7 @@ interface GoalCardProps {
     iconId?: number;
     status?: GoalStatus;
     savedAmount?: number;
+    collectedAmount?: number;
   };
   type?: 'current' | 'past';
 }
@@ -51,7 +53,12 @@ const GoalCard = ({ goal, type = 'current' }: GoalCardProps) => {
       statusClass = 'bg-gray-200 text-gray-600';
     }
   } else {
-    statusLabel = `${goal.progress}% 달성`;
+    const achieved = isGoalAchieved({
+      targetAmount: goal.targetAmount,
+      currentBalance: goal.collectedAmount,
+      savedAmount: goal.savedAmount,
+    });
+    statusLabel = achieved ? '달성완료' : `${goal.progress}% 달성`;
     statusClass = 'bg-primary-normal text-[#171714]';
   }
 
@@ -97,7 +104,7 @@ const GoalCard = ({ goal, type = 'current' }: GoalCardProps) => {
               <span className="text-xs font-medium">달성금액</span>
             </div>
             <span className="text-xs font-semibold text-[#171714]">
-              {(goal.savedAmount ?? goal.targetAmount).toLocaleString()}원
+              {(goal.collectedAmount ?? goal.savedAmount ?? goal.targetAmount).toLocaleString()}원
             </span>
           </div>
         </div>

--- a/src/shared/components/goal/detail/GoalProgressGauge.tsx
+++ b/src/shared/components/goal/detail/GoalProgressGauge.tsx
@@ -54,9 +54,12 @@ const GoalProgressGauge = ({ goalId, extraSavingAmount }: GoalProgressGaugeProps
   return (
     <div className="relative overflow-hidden bg-white min-h-[50px] flex flex-col justify-start pb-6 px-5  mx-5">
       <div
-        className="absolute bottom-0 left-0 w-full transition-all duration-1000 ease-out bg-primary-normal"
+        className="absolute bottom-0 left-0 w-full overflow-hidden transition-all duration-1000 ease-out bg-primary-normal"
         style={{ height: `${clampedRate}%` }}
-      />
+      >
+        <div className="goal-gauge-wave" />
+        <div className="goal-gauge-wave goal-gauge-wave-secondary" />
+      </div>
 
       <div className="relative z-10">
         <div className="flex items-center gap-2 mb-5 mt-5">

--- a/src/shared/components/goal/detail/GoalProgressGauge.tsx
+++ b/src/shared/components/goal/detail/GoalProgressGauge.tsx
@@ -5,7 +5,7 @@ import ExBank from '@/assets/icons/goal/ExBank.svg';
 import { getCollectedAmount } from '@/shared/utils/goal/goalHelpers';
 interface GoalProgressGaugeProps {
   goalId: number;
-  /** 목표 계산기에서 모으기로 한 금액 (원 단위, 전달되면 이 값만 모은 금액으로 사용) */
+  /** 목표 계산기에서 추가로 절약할 금액 (원 단위) */
   extraSavingAmount?: number;
 }
 
@@ -43,9 +43,10 @@ const GoalProgressGauge = ({ goalId, extraSavingAmount }: GoalProgressGaugeProps
     (account) => account.goalInfo?.goalId === goalId
   )?.balanceAmount;
 
-  // 모인 금액: 시뮬레이션 값 > 연결 계좌 잔액 > 목표 상세 응답 순으로 사용
-  const totalSavedForGauge =
-    extraSavingAmount != null ? extraSavingAmount : (linkedAccountBalance ?? getCollectedAmount(goalData));
+  const baseCollectedAmount = linkedAccountBalance ?? getCollectedAmount(goalData);
+
+  // 모인 금액: 기본 잔액 + (시뮬레이션 추가 절약 금액)
+  const totalSavedForGauge = extraSavingAmount != null ? baseCollectedAmount + extraSavingAmount : baseCollectedAmount;
   const rawRate = targetAmount > 0 ? (totalSavedForGauge / targetAmount) * 100 : 0;
   // 0~100으로 클램프, 소수점은 반올림 처리
   const clampedRate = Math.min(Math.max(Math.round(rawRate), 0), 100);

--- a/src/shared/components/goal/detail/GoalProgressGauge.tsx
+++ b/src/shared/components/goal/detail/GoalProgressGauge.tsx
@@ -1,4 +1,5 @@
 import { useGoalDetail, toHexColor } from '@/features/goal';
+import { useAccounts } from '@/features/asset';
 import { GOAL_ICON_SRC } from '@/shared/components/goal/goalIconAssets';
 import ExBank from '@/assets/icons/goal/ExBank.svg';
 import { getCollectedAmount } from '@/shared/utils/goal/goalHelpers';
@@ -10,6 +11,7 @@ interface GoalProgressGaugeProps {
 
 const GoalProgressGauge = ({ goalId, extraSavingAmount }: GoalProgressGaugeProps) => {
   const { data, isLoading: loading, error: queryError } = useGoalDetail(goalId);
+  const { data: accountsData } = useAccounts();
   const goalData = data?.result ?? null;
   const error = queryError ? '데이터를 불러오는데 실패했습니다.' : null;
 
@@ -36,8 +38,14 @@ const GoalProgressGauge = ({ goalId, extraSavingAmount }: GoalProgressGaugeProps
   // 목표 금액: 항상 생성 시 입력한 원래 목표 금액 사용
   const targetAmount = goalData.targetAmount;
 
-  // 모인 금액: 현재 잔액 기준으로 계산하고, 시뮬레이션 값이 있으면 우선 적용
-  const totalSavedForGauge = extraSavingAmount != null ? extraSavingAmount : getCollectedAmount(goalData);
+  // 연결된 목표의 계좌 잔액을 우선 사용 (없으면 목표 상세 응답의 잔액 계열 필드 fallback)
+  const linkedAccountBalance = accountsData?.result?.accountList?.find(
+    (account) => account.goalInfo?.goalId === goalId
+  )?.balanceAmount;
+
+  // 모인 금액: 시뮬레이션 값 > 연결 계좌 잔액 > 목표 상세 응답 순으로 사용
+  const totalSavedForGauge =
+    extraSavingAmount != null ? extraSavingAmount : (linkedAccountBalance ?? getCollectedAmount(goalData));
   const rawRate = targetAmount > 0 ? (totalSavedForGauge / targetAmount) * 100 : 0;
   // 0~100으로 클램프, 소수점은 반올림 처리
   const clampedRate = Math.min(Math.max(Math.round(rawRate), 0), 100);

--- a/src/shared/components/goal/detail/GoalProgressGauge.tsx
+++ b/src/shared/components/goal/detail/GoalProgressGauge.tsx
@@ -1,6 +1,7 @@
 import { useGoalDetail, toHexColor } from '@/features/goal';
 import { GOAL_ICON_SRC } from '@/shared/components/goal/goalIconAssets';
 import ExBank from '@/assets/icons/goal/ExBank.svg';
+import { getCollectedAmount } from '@/shared/utils/goal/goalHelpers';
 interface GoalProgressGaugeProps {
   goalId: number;
   /** 목표 계산기에서 모으기로 한 금액 (원 단위, 전달되면 이 값만 모은 금액으로 사용) */
@@ -35,8 +36,8 @@ const GoalProgressGauge = ({ goalId, extraSavingAmount }: GoalProgressGaugeProps
   // 목표 금액: 항상 생성 시 입력한 원래 목표 금액 사용
   const targetAmount = goalData.targetAmount;
 
-  // 모인 금액: extraSavingAmount가 있으면 그 값만 사용, 없으면 API의 savedAmount 사용
-  const totalSavedForGauge = extraSavingAmount != null ? extraSavingAmount : goalData.savedAmount;
+  // 모인 금액: 현재 잔액 기준으로 계산하고, 시뮬레이션 값이 있으면 우선 적용
+  const totalSavedForGauge = extraSavingAmount != null ? extraSavingAmount : getCollectedAmount(goalData);
   const rawRate = targetAmount > 0 ? (totalSavedForGauge / targetAmount) * 100 : 0;
   // 0~100으로 클램프, 소수점은 반올림 처리
   const clampedRate = Math.min(Math.max(Math.round(rawRate), 0), 100);
@@ -67,7 +68,7 @@ const GoalProgressGauge = ({ goalId, extraSavingAmount }: GoalProgressGaugeProps
           <span className="text-sm font-semibold text-[#171714] font-pretendard">{goalData.title}</span>
         </div>
 
-        <div className="px-1 mb-1.5 text-sm font-medium text-gray-600 font-pretendard">총 모인 금액</div>
+        <div className="px-1 mb-1.5 text-sm font-medium text-gray-600 font-pretendard">현재 보유 자산</div>
 
         <div className="flex items-center gap-4 px-1">
           <span className="text-2xl font-bold text-black leading-tight font-pretendard">

--- a/src/shared/components/goal/detail/PastGoalSummarySection.tsx
+++ b/src/shared/components/goal/detail/PastGoalSummarySection.tsx
@@ -2,6 +2,7 @@ import { toHexColor } from '@/features/goal';
 import type { GoalDetail } from '@/features/goal';
 import { GOAL_ICON_SRC } from '@/shared/components/goal/goalIconAssets';
 import ExBank from '@/assets/icons/goal/ExBank.svg';
+import { getCollectedAmount } from '@/shared/utils/goal/goalHelpers';
 
 interface PastGoalSummarySectionProps {
   detail: GoalDetail;
@@ -18,8 +19,7 @@ export default function PastGoalSummarySection({ detail }: PastGoalSummarySectio
   const achievementPillClass =
     detail.status === 'COMPLETE' ? 'bg-primary-normal text-[#171714]' : 'bg-neutral-20 text-neutral-70';
 
-  /** 달성 성공이면 총 모인금액 = 목표 금액으로 표시 (서버가 0을 줄 수 있음) */
-  const totalCollectedAmount = detail.status === 'COMPLETE' ? detail.targetAmount : detail.savedAmount;
+  const totalCollectedAmount = getCollectedAmount(detail);
 
   return (
     <div className="relative overflow-hidden bg-primary-normal px-5 pt-5 pb-8">
@@ -41,7 +41,7 @@ export default function PastGoalSummarySection({ detail }: PastGoalSummarySectio
         <span className="text-sm font-semibold text-[#171714]">{detail.title}</span>
       </div>
 
-      <p className="text-sm font-medium text-neutral-50 mb-1">총 모인금액</p>
+      <p className="text-sm font-medium text-neutral-50 mb-1">현재 보유 자산</p>
       <div className="flex items-center gap-3 flex-wrap">
         <span className="text-2xl font-bold text-[#171714] leading-tight">{formatAmount(totalCollectedAmount)} 원</span>
         <span className={`px-3 py-1 rounded-full text-xs font-bold ${achievementPillClass}`}>{achievementLabel}</span>

--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -158,3 +158,47 @@
   background-size: 200% 100%;
   pointer-events: none;
 }
+
+@keyframes goal-gauge-wave-primary {
+  0% {
+    transform: translateX(-14%) translateY(0);
+  }
+  50% {
+    transform: translateX(6%) translateY(-6px);
+  }
+  100% {
+    transform: translateX(-14%) translateY(0);
+  }
+}
+
+@keyframes goal-gauge-wave-secondary {
+  0% {
+    transform: translateX(12%) translateY(0);
+  }
+  50% {
+    transform: translateX(-8%) translateY(5px);
+  }
+  100% {
+    transform: translateX(12%) translateY(0);
+  }
+}
+
+.goal-gauge-wave {
+  position: absolute;
+  left: -18%;
+  top: -14px;
+  width: 136%;
+  height: 28px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.36);
+  filter: blur(0.2px);
+  animation: goal-gauge-wave-primary 1.45s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.goal-gauge-wave-secondary {
+  top: -8px;
+  height: 20px;
+  opacity: 0.55;
+  animation: goal-gauge-wave-secondary 1.25s ease-in-out infinite;
+}

--- a/src/shared/utils/goal/goalHelpers.ts
+++ b/src/shared/utils/goal/goalHelpers.ts
@@ -139,3 +139,42 @@ export function maskAccountNumber(accountNumber: string): string {
   }
   return accountNumber;
 }
+
+interface GoalAmountSource {
+  savedAmount?: number | null;
+  currentBalance?: number | null;
+  account?: {
+    balanceAmount?: number | null;
+    currentBalance?: number | null;
+  } | null;
+  targetAmount?: number | null;
+}
+
+/** 목표의 "모은 금액"을 현재 잔액 기준으로 계산한다. */
+export function getCollectedAmount(goal: GoalAmountSource, fallback = 0): number {
+  const fromGoalCurrentBalance = goal.currentBalance;
+  if (typeof fromGoalCurrentBalance === 'number') return fromGoalCurrentBalance;
+
+  const fromAccountCurrentBalance = goal.account?.currentBalance;
+  if (typeof fromAccountCurrentBalance === 'number') return fromAccountCurrentBalance;
+
+  const fromAccountBalanceAmount = goal.account?.balanceAmount;
+  if (typeof fromAccountBalanceAmount === 'number') return fromAccountBalanceAmount;
+
+  const fromSavedAmount = goal.savedAmount;
+  if (typeof fromSavedAmount === 'number') return fromSavedAmount;
+
+  return fallback;
+}
+
+/** 남은 목표 금액 = 목표 금액 - 현재 잔액(모은 금액), 최소 0원 */
+export function getRemainingGoalAmount(goal: GoalAmountSource): number {
+  const targetAmount = goal.targetAmount ?? 0;
+  return Math.max(targetAmount - getCollectedAmount(goal), 0);
+}
+
+/** 목표 달성 여부 = 현재 잔액(모은 금액) >= 목표 금액 */
+export function isGoalAchieved(goal: GoalAmountSource): boolean {
+  const targetAmount = goal.targetAmount ?? 0;
+  return getCollectedAmount(goal) >= targetAmount;
+}


### PR DESCRIPTION
# [refactor] 목표 달성 계산 기준 및 남은 금액/현재 자산 UI 로직 수정

## 📝 변경 내용
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 목표 금액 계산 기준을 현재 잔액 기반으로 변경 (달성 금액, 남은 목표 금액, 달성 여부 로직 반영)
- 목표 상세/절약 시뮬레이션에서 연결 계좌 잔액 우선 반영하도록 수정해 0원 표시 이슈 해결
- 추천 화면에서 상품 리스트 중복 key 경고 해결 (중복 제거 + 안정적인 key 처리)
- 자산 화면에서 button 중첩 DOM 경고 해결 (button > button 구조 제거)
- goal.api, 카테고리 비교 등 불필요한 디버그 로그 정리
- 목표 게이지 채움에 애니메이션 추가

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
- Closes #157

## 🎯 변경 사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 개선
- [x] 리팩토링
- [ ] 문서 업데이트

## 📱 테스트
- [x] 브라우저에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인

## 📸 스크린샷 (UI 변경시)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/baf8addd-d6db-4eae-bc41-83e4d72cd24b


## 📋 체크리스트
- [x] 코드가 정상적으로 동작합니다
- [x] 새로운 에러나 경고가 없습니다
- [x] 필요시 문서를 업데이트했습니다
- [x] 코드 포맷팅을 실행했습니다 (`npm run format`)
- [x] ESLint 검사를 통과했습니다 (`npm run lint:fix`)

## 💻 코드 품질 확인
PR 제출 전에 다음 명령어를 실행하여 코드 품질을 확인해주세요:

```bash
# ESLint 자동 수정
npm run lint:fix

# Prettier 포맷팅
npm run format
```

